### PR TITLE
Fix duplicate Logger import

### DIFF
--- a/pol/server.py
+++ b/pol/server.py
@@ -6,6 +6,11 @@ import pickle
 import time, sys, traceback
 import re
 
+try:
+    from urllib.parse import urlparse
+except ImportError:  # Python 2 fallback
+    from urlparse import urlparse
+
 import six
 from lxml import etree
 
@@ -31,9 +36,6 @@ from scrapy.selector import Selector
 from pol.log import LogHandler
 from .feed import Feed
 from .client import ppReadBody, IGNORE_SIZE
-
-from twisted.logger import Logger
-
 
 log = Logger()
 


### PR DESCRIPTION
## Summary
- remove a duplicate `Logger` import in `pol/server.py`
- add `urlparse` import for missing reference

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twisted')*

------
https://chatgpt.com/codex/tasks/task_e_683b2757407c8326abfbe203301cee13