### PR TITLE
Fix static server test and add sample pages

### DIFF
--- a/tests/pages/about.html
+++ b/tests/pages/about.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>About Test</title>
+</head>
+<body>
+    <h1>About Page</h1>
+    <p>Another page served by the static server.</p>
+</body>
+</html>

--- a/tests/pages/index.html
+++ b/tests/pages/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test Index</title>
+</head>
+<body>
+    <h1>Index Page</h1>
+    <p>This is a sample index page for tests.</p>
+</body>
+</html>

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -17,14 +17,28 @@ class MFTests(object):
         self.log = Logger()
 
     def start_static(self):
-        resource = File(os.getcwd() + '/tests/pages')
+        """Start a static file server for the sample pages."""
+        pages_dir = os.path.join(os.path.dirname(__file__), 'pages')
+        resource = File(pages_dir)
         factory = Site(resource)
-        endpoint = endpoints.TcP4ServerEndpoint(reactor, 0)
-        endpoint.listen(factory)
-        # reactor.run()
+        endpoint = endpoints.TCP4ServerEndpoint(reactor, 0)
+        d = endpoint.listen(factory)
 
-    def send_request(self):
-        pass
+        def store_port(port):
+            self.static_port = port.getHost().port
+            return port
+
+        d.addCallback(store_port)
+        return d
+
+    def send_request(self, path='/index.html'):
+        from twisted.web.client import Agent, readBody
+
+        url = 'http://127.0.0.1:%d%s' % (self.static_port, path)
+        agent = Agent(reactor)
+        d = agent.request(b'GET', url.encode('ascii'))
+        d.addCallback(readBody)
+        return d
 
     def stop_callback(self, none):
         reactor.stop()
@@ -40,6 +54,20 @@ class MFTests(object):
         reactor.callLater(0, d.callback, None)
         d.addCallback(self.stop_callback)
         d.addErrback(lambda err: print("callback error: %s\ncallback traceback: %s" % (err.getErrorMessage(), err.getTraceback())))
+
+        reactor.run()
+
+    def test_static_server(self):
+        d = self.start_static()
+        d.addCallback(lambda _: self.send_request('/index.html'))
+
+        def check_body(body):
+            if b'Index Page' not in body:
+                raise AssertionError('Index page not served')
+
+        d.addCallback(check_body)
+        d.addCallback(self.stop_callback)
+        d.addErrback(lambda err: print("callback error: %s\ncallback traceback: %s" % (getattr(err, 'getErrorMessage', lambda: err)(), getattr(err, 'getTraceback', lambda: '')())))
 
         reactor.run()
 


### PR DESCRIPTION
## Summary
- fix MFTests.start_static to use `endpoints.TCP4ServerEndpoint`
- add sample HTML pages for tests
- add test for static server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twisted')*

------
https://chatgpt.com/codex/tasks/task_e_683b27fb89948326982eda9256af2cd1