### PR TITLE
Fix test.py invocation

### DIFF
--- a/test.py
+++ b/test.py
@@ -6,4 +6,5 @@ def main():
     ts.test_log_handler()
     ts.test_server()
 
-main()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `__main__` guard so `main()` runs cleanly
- ensure `test.py` ends with a newline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twisted')*

------
https://chatgpt.com/codex/tasks/task_e_683b7d2b17b4832694fa32a1e6a23283