### PR TITLE
Update project for Python 3

### DIFF
--- a/frontend/frontend/views.py
+++ b/frontend/frontend/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponseRedirect, HttpResponse, HttpResponseBadReque
 from django.shortcuts import render
 from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from .forms import IndexForm
 from .settings import DOWNLOADER_PAGE_URL, FEED_PAGE_URL

--- a/readme.md
+++ b/readme.md
@@ -12,20 +12,20 @@ This is source code of RSS feed generator website with user friendly interface.
 
 Install required packages
 ```
-sudo apt-get install python-minimal libmysqlclient-dev libxml2-dev libxslt-dev python-dev libffi-dev gcc libssl-dev gettext
+sudo apt-get install python3-minimal libmysqlclient-dev libxml2-dev libxslt-dev python3-dev libffi-dev gcc libssl-dev gettext
 ```
 
 Install pip
 ```
 pushd /tmp
 wget https://bootstrap.pypa.io/get-pip.py
-sudo python get-pip.py
+sudo python3 get-pip.py
 popd
 ```
 
 Install pip packages
 ```
-sudo pip install -r pol/requirements.txt
+sudo pip3 install -r requirements.txt
 ```
 
 Install less and yuglify
@@ -75,8 +75,8 @@ cp pol/frontend/frontend/settings.py.example pol/frontend/frontend/settings.py
 Initialise database
 ```
 pushd pol/frontend
-python manage.py migrate
-python manage.py loaddata fields.json
+python3 manage.py migrate
+python3 manage.py loaddata fields.json
 popd
 ```
 
@@ -85,14 +85,14 @@ popd
 Run downloader server
 ```
 pushd pol
-python downloader.py
+python3 downloader.py
 popd
 ```
 
 Run frontend server
 ```
 pushd pol/frontend
-python manage.py runserver
+python3 manage.py runserver
 popd
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 #sudo apt-get install libmysqlclient-dev libxml2-dev libxslt-dev python-dev libffi-dev gcc libssl-dev gettext
-Django>=2.2
-lxml>=4.0
+Django>=3.2
+lxml>=4.9
 Scrapy>=2.8
 django-pipeline>=2.0
-mysqlclient>=2.0
-w3lib>=1.17.0
-feedgenerator>=1.8
-brotli>=1.0.0
+mysqlclient>=2.1
+w3lib>=1.21
+feedgenerator>=1.9
+brotli>=1.0.9
 sqlparse>=0.4.4
 #sudo apt-get install nodejs npm
 #sudo npm install -g less


### PR DESCRIPTION
## Summary
- upgrade package versions for Python3 compatibility
- switch Django url import to `django.urls` in views
- update docs for Python3 tooling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twisted')*
- `python3 downloader.py 8088` *(fails: No module named 'lxml')*

------
https://chatgpt.com/codex/tasks/task_e_683bdfab55bc8326a942b4c26190e1b6