### PR TITLE
Add login support and user feeds

### DIFF
--- a/frontend/frontend/migrations/0009_feed_user.py
+++ b/frontend/frontend/migrations/0009_feed_user.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('frontend', '0008_auto_20180215_1445'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='feed',
+            name='user',
+            field=models.ForeignKey(blank=True, null=True, on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL),
+        ),
+    ]
+

--- a/frontend/frontend/models.py
+++ b/frontend/frontend/models.py
@@ -1,8 +1,10 @@
 from django.db import models
+from django.contrib.auth.models import User
 
 class Feed(models.Model):
     uri = models.CharField(max_length=2000)
     xpath = models.CharField(max_length=2000)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
     edited = models.BooleanField(default=False)
     created = models.DateTimeField(auto_now_add=True)
 

--- a/frontend/frontend/templates/base.html
+++ b/frontend/frontend/templates/base.html
@@ -63,7 +63,11 @@
             <li>{% if LANGUAGE_CODE == 'en' %} <a href="/ru/" class="lang"><span class="lang">Русский</span></a> {% else %} <span class="lang">Русский</span> {% endif %}
             <li class="divider-vertical"></li>
             <li><a href="{% url 'contact' %}">{% trans "contact" %}</a></li>
-            <!--%= render 'devise/menu/login_items' %-->
+            {% if user.is_authenticated %}
+            <li><a href="{% url 'logout' %}">{% trans 'logout' %}</a></li>
+            {% else %}
+            <li><a href="{% url 'login' %}">{% trans 'login' %}</a></li>
+            {% endif %}
           </ul>
         </div>
         <!--/.nav-collapse -->
@@ -74,10 +78,10 @@
 <div class="middler" style="{% if side_menu %} padding-bottom: 50px/*for footer*/ {% endif %}">
 <div class="container">
   <div class="row-fluid">
-    {% if user_signed_in %}
+    {% if user.is_authenticated %}
       {% block side_menu %}{% endblock %}
     {% endif %}
-    <div class="<%= (user_signed_in? && content_for?(:side_menu)) ? 'span9' : 'span12' %>">
+    <div class="{% if user.is_authenticated and side_menu %}span9{% else %}span12{% endif %}">
       {% block content %}{% endblock %}
     </div>
   </div>

--- a/frontend/frontend/templates/registration/logged_out.html
+++ b/frontend/frontend/templates/registration/logged_out.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<p>You have been logged out.</p>
+<a href="{% url 'login' %}">Login again</a>
+{% endblock %}

--- a/frontend/frontend/templates/registration/login.html
+++ b/frontend/frontend/templates/registration/login.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Login</button>
+</form>
+<p>Don't have an account? <a href="{% url 'register' %}">Register</a></p>
+{% endblock %}

--- a/frontend/frontend/templates/registration/register.html
+++ b/frontend/frontend/templates/registration/register.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>Register</h2>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Register</button>
+</form>
+{% endblock %}

--- a/frontend/frontend/urls.py
+++ b/frontend/frontend/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
+from django.urls import path
 
 from . import views
 
@@ -26,6 +27,11 @@ urlpatterns = i18n_patterns(
     url(r'^contact$', views.contact, name='contact'),
     url(r'^admin/', include(admin.site.urls)),
 )
+
+urlpatterns += [
+    path('accounts/', include('django.contrib.auth.urls')),
+    path('register/', views.register, name='register'),
+]
 
 urlpatterns.append(url(r'^setup_get_selected_ids$', views.setup_get_selected_ids, name='setup_get_selected_ids'))
 urlpatterns.append(url(r'^setup_create_feed$', views.setup_create_feed, name='setup_create_feed'))


### PR DESCRIPTION
## Summary
- enable Django auth and provide login/logout links
- support registering new users
- relate feeds to users
- require authentication for creating feeds

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twisted')*

------
https://chatgpt.com/codex/tasks/task_e_683be282405483268163c0780246c252