### PR TITLE
Update middleware settings

### DIFF
--- a/frontend/frontend/settings.py
+++ b/frontend/frontend/settings.py
@@ -44,13 +44,12 @@ INSTALLED_APPS = (
     'frontend',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',


### PR DESCRIPTION
## Summary
- modernize middleware configuration
- remove deprecated `SessionAuthenticationMiddleware`

## Testing
- `python3 frontend/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683be87fcee883269f316b13a967f8e1