### PR TITLE
Fix unused import warnings

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -1,6 +1,6 @@
 import sys
 from pol.server import Server
-from settings import DATABASES, SNAPSHOT_DIR, DOWNLOADER_USER_AGENT, DEBUG
+from settings import DATABASES, SNAPSHOT_DIR, DOWNLOADER_USER_AGENT
 
 
 port = sys.argv[1] if len(sys.argv) >= 2 else 1234

--- a/frontend/frontend/migrations/0005_auto_20180131_1949.py
+++ b/frontend/frontend/migrations/0005_auto_20180131_1949.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from django.db import migrations, models
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/frontend/frontend/setup_tool_ext.py
+++ b/frontend/frontend/setup_tool_ext.py
@@ -1,4 +1,3 @@
-from hashlib import md5
 
 from scrapy.selector import Selector
 

--- a/pol/client.py
+++ b/pol/client.py
@@ -1,19 +1,10 @@
 import warnings
 
-from twisted.python.failure import Failure
 from twisted.internet import defer, protocol, reactor
 from twisted.web._newclient import (
-    HTTP11ClientProtocol,
     PotentialDataLoss,
-    Request,
-    RequestGenerationFailed,
-    RequestNotSent,
-    RequestTransmissionFailed,
-    Response,
     ResponseDone,
     ResponseFailed,
-    ResponseNeverReceived,
-    _WrapperException,
     )
 from twisted.web.client import PartialDownloadError
 

--- a/pol/feed.py
+++ b/pol/feed.py
@@ -1,16 +1,13 @@
 import w3lib.url
 import w3lib.html
 
-from lxml import etree
-import re, sys
+import re
 from hashlib import md5
 
-from feedgenerator import Rss201rev2Feed, Enclosure
+from feedgenerator import Rss201rev2Feed
 import datetime
 
-import MySQLdb
 from contextlib import closing
-from settings import DATABASES, DOWNLOADER_USER_AGENT
 from twisted.logger import Logger
 
 from .db import get_conn

--- a/pol/server.py
+++ b/pol/server.py
@@ -15,7 +15,7 @@ from lxml import etree
 
 from twisted.web import server, resource
 from twisted.internet import reactor, endpoints, defer
-from twisted.web.client import Agent, BrowserLikeRedirectAgent, PartialDownloadError, HTTPConnectionPool
+from twisted.web.client import Agent, BrowserLikeRedirectAgent, PartialDownloadError
 from twisted.web.server import NOT_DONE_YET
 from twisted.web.http_headers import Headers
 from twisted.web.http import INTERNAL_SERVER_ERROR
@@ -30,7 +30,6 @@ from scrapy.http.request import Request
 from scrapy.http import Headers
 from scrapy.responsetypes import responsetypes
 from scrapy.core.downloader.contextfactory import ScrapyClientContextFactory
-from scrapy.selector import Selector
 
 from pol.log import LogHandler
 from .feed import Feed

--- a/tests/test_build_feed.py
+++ b/tests/test_build_feed.py
@@ -1,4 +1,3 @@
-import json
 import datetime
 import pytest
 


### PR DESCRIPTION
## Summary
- remove unused DEBUG import in downloader
- tidy unused imports across the repo

## Testing
- `ruff check . --select F401`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bf14d781483268d8bead5a33fe24f