### PR TITLE
Add simple user dashboard

### DIFF
--- a/frontend/frontend/templates/base.html
+++ b/frontend/frontend/templates/base.html
@@ -61,6 +61,7 @@
             <li><div class="vr mx-2"></div></li>
             <li><a href="{% url 'contact' %}">{% trans "contact" %}</a></li>
             {% if user.is_authenticated %}
+            <li><a href="{% url 'dashboard' %}">Dashboard</a></li>
             <li><a href="{% url 'logout' %}">{% trans 'logout' %}</a></li>
             {% else %}
             <li><a href="{% url 'login' %}">{% trans 'login' %}</a></li>

--- a/frontend/frontend/templates/frontend/dashboard.html
+++ b/frontend/frontend/templates/frontend/dashboard.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+<div class="page-header">
+  <h1>{% trans 'Dashboard' %}</h1>
+</div>
+<table class="table">
+  <thead>
+    <tr>
+      <th>URL</th>
+      <th>{% trans 'Created' %}</th>
+      <th>{% trans 'Actions' %}</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for feed in feeds %}
+    <tr>
+      <td>{{ feed.uri }}</td>
+      <td>{{ feed.created|date:"Y-m-d H:i" }}</td>
+      <td>
+        <a class="btn btn-sm btn-primary" href="{% url 'preview' feed.id %}">{% trans 'View' %}</a>
+        <a class="btn btn-sm btn-secondary" href="{% url 'setup' %}?url={{ feed.uri|urlencode }}">{% trans 'Edit' %}</a>
+        <form method="post" action="{% url 'delete_feed' feed.id %}" style="display:inline;">
+          {% csrf_token %}
+          <button type="submit" class="btn btn-sm btn-danger">{% trans 'Delete' %}</button>
+        </form>
+      </td>
+    </tr>
+  {% empty %}
+    <tr><td colspan="3">{% trans 'No feeds.' %}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/frontend/frontend/urls.py
+++ b/frontend/frontend/urls.py
@@ -25,12 +25,14 @@ urlpatterns = i18n_patterns(
     url(r'^setup$', views.setup, name='setup'),
     url(r'^preview/([0-9]+)$', views.preview, name='preview'),
     url(r'^contact$', views.contact, name='contact'),
+    url(r'^dashboard$', views.dashboard, name='dashboard'),
     url(r'^admin/', include(admin.site.urls)),
 )
 
 urlpatterns += [
     path('accounts/', include('django.contrib.auth.urls')),
     path('register/', views.register, name='register'),
+    path('dashboard/delete/<int:feed_id>/', views.delete_feed, name='delete_feed'),
 ]
 
 urlpatterns.append(url(r'^setup_get_selected_ids$', views.setup_get_selected_ids, name='setup_get_selected_ids'))

--- a/frontend/frontend/views.py
+++ b/frontend/frontend/views.py
@@ -4,7 +4,7 @@ import re
 
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.http import HttpResponseRedirect, HttpResponse, HttpResponseBadRequest
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
 from django.urls import reverse
@@ -238,3 +238,17 @@ def register(request):
     else:
         form = UserCreationForm()
     return render(request, 'registration/register.html', {'form': form})
+
+
+@login_required
+def dashboard(request):
+    feeds = Feed.objects.filter(user=request.user).order_by('-created')
+    return render(request, 'frontend/dashboard.html', {'feeds': feeds})
+
+
+@login_required
+def delete_feed(request, feed_id):
+    if request.method == 'POST':
+        feed = get_object_or_404(Feed, id=feed_id, user=request.user)
+        feed.delete()
+    return HttpResponseRedirect(reverse('dashboard'))


### PR DESCRIPTION
## Summary
- add dashboard and deletion endpoints
- show user's feeds on new dashboard template
- link dashboard in navbar when logged in

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bf9e4d2a0832681206b1ae54a8fbc