### PR TITLE
Add subscription model and admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+PAYMENT_API_KEY=your_payment_api_key
+SUBSCRIPTION_API_KEY=your_subscription_api_key
+DEFAULT_PLAN=basic

--- a/frontend/frontend/__init__.py
+++ b/frontend/frontend/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'frontend.apps.FrontendConfig'

--- a/frontend/frontend/admin.py
+++ b/frontend/frontend/admin.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+
+from .models import Feed, Field, FeedField, Post, Subscription
+
+
+@admin.register(Subscription)
+class SubscriptionAdmin(admin.ModelAdmin):
+    list_display = ('user', 'plan', 'status', 'start_date', 'end_date')
+    list_filter = ('status', 'plan')
+    search_fields = ('user__username',)

--- a/frontend/frontend/apps.py
+++ b/frontend/frontend/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class FrontendConfig(AppConfig):
+    name = 'frontend'
+
+    def ready(self):
+        # Import signals to ensure they are registered
+        from . import signals  # noqa

--- a/frontend/frontend/migrations/0010_subscription.py
+++ b/frontend/frontend/migrations/0010_subscription.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('frontend', '0009_feed_user'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Subscription',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('plan', models.CharField(max_length=50)),
+                ('status', models.CharField(choices=[('active', 'Active'), ('inactive', 'Inactive'), ('canceled', 'Canceled')], default='active', max_length=20)),
+                ('start_date', models.DateField()),
+                ('end_date', models.DateField(blank=True, null=True)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('updated', models.DateTimeField(auto_now=True)),
+                ('user', models.ForeignKey(on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/frontend/frontend/models.py
+++ b/frontend/frontend/models.py
@@ -24,3 +24,22 @@ class Post(models.Model):
 
     class Meta:
         index_together = ['feed', 'md5sum']
+
+
+class Subscription(models.Model):
+    STATUS_CHOICES = [
+        ('active', 'Active'),
+        ('inactive', 'Inactive'),
+        ('canceled', 'Canceled'),
+    ]
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    plan = models.CharField(max_length=50)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='active')
+    start_date = models.DateField()
+    end_date = models.DateField(null=True, blank=True)
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return f"{self.user.username} - {self.plan} ({self.status})"

--- a/frontend/frontend/settings.py
+++ b/frontend/frontend/settings.py
@@ -41,7 +41,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.sites',
     'pipeline',
-    'frontend',
+    'frontend.apps.FrontendConfig',
 )
 
 MIDDLEWARE = (
@@ -175,3 +175,8 @@ DOWNLOADER_USER_AGENT = 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 
 # limit of seconds in which user can access separate feed
 FEED_REQUEST_PERIOD_LIMIT = 0
 SNAPSHOT_DIR = '/tmp'
+
+# API keys for payment/subscription providers
+PAYMENT_API_KEY = os.environ.get('PAYMENT_API_KEY', '')
+SUBSCRIPTION_API_KEY = os.environ.get('SUBSCRIPTION_API_KEY', '')
+DEFAULT_PLAN = os.environ.get('DEFAULT_PLAN', 'basic')

--- a/frontend/frontend/signals.py
+++ b/frontend/frontend/signals.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.utils import timezone
+
+from .models import Subscription
+
+
+@receiver(post_save, sender=User)
+def create_default_subscription(sender, instance, created, **kwargs):
+    if created:
+        Subscription.objects.create(
+            user=instance,
+            plan=getattr(settings, 'DEFAULT_PLAN', 'basic'),
+            status='active',
+            start_date=timezone.now().date(),
+        )


### PR DESCRIPTION
## Summary
- implement `Subscription` model and migration
- expose payment API keys via environment variables
- register a signal for creating a default subscription at sign up
- configure app via `FrontendConfig`
- register Subscription model in Django admin
- provide `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bfc2903348326abbfdb64392641b9