### PR TITLE
Fix local page hashing and response writing

### DIFF
--- a/pol/server.py
+++ b/pol/server.py
@@ -307,7 +307,7 @@ class Site(resource.Resource):
             if selector_defer:
                 reactor.callLater(0, selector_defer.callback, sresponse)
             else:
-                downloader.writeResponse(request, sresponse, feed_config)
+                downloader.writeResponse(sresponse)
         else:
             agent = BrowserLikeRedirectAgent(
                 Agent(reactor,
@@ -333,7 +333,7 @@ class Site(resource.Resource):
 
     def tryLocalPage(self, url):
         if self.prefetch_dir:
-            m = md5(url).hexdigest()
+            m = md5(url.encode('utf-8')).hexdigest()
             domain = urlparse(url).netloc
             try:
                 with open(self.prefetch_dir + '/' + m + '.' + domain) as f:


### PR DESCRIPTION
## Summary
- compute md5 hash with explicit UTF-8 encoding when looking up prefetched pages
- call `Downloader.writeResponse` with only the response object in `Site.startRequest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f497d8b408326ba9050d1b3b46bc4