### PR TITLE
Fix md5 initialization in Feed

### DIFF
--- a/pol/feed.py
+++ b/pol/feed.py
@@ -42,7 +42,9 @@ class Feed(object):
         new_post_cnt = 0
         for item in items:
             #create md5
-            h = md5('')
+            # Initialize the md5 hasher with no data instead of passing an
+            # empty string which is deprecated in newer Python versions.
+            h = md5()
             for key in ['title', 'description', 'link']:
                 if key in item:
                     h.update(item[key].encode('utf-8'))


### PR DESCRIPTION
## Summary
- fix md5() call in `Feed.fill_time`
- add comment about avoiding deprecated empty string argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f4a4fe6348326b1fae16d05ee10dd