### PR TITLE
Add __str__ methods for feed models

### DIFF
--- a/frontend/frontend/models.py
+++ b/frontend/frontend/models.py
@@ -8,14 +8,28 @@ class Feed(models.Model):
     edited = models.BooleanField(default=False)
     created = models.DateTimeField(auto_now_add=True)
 
+    def __str__(self):
+        """Return a human readable representation of the feed."""
+        return self.uri
+
 class Field(models.Model):
     name = models.CharField(max_length=200)
     required = models.BooleanField(default=True)
+
+    def __str__(self):
+        """Return the name of the field."""
+        return self.name
 
 class FeedField(models.Model):
     feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
     field = models.ForeignKey(Field, on_delete=models.CASCADE)
     xpath = models.CharField(max_length=2000)
+
+    def __str__(self):
+        """Describe which field belongs to which feed."""
+        feed_str = getattr(self.feed, 'uri', str(self.feed))
+        field_str = getattr(self.field, 'name', str(self.field))
+        return f"{feed_str} - {field_str}"
 
 class Post(models.Model):
     feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
@@ -24,6 +38,11 @@ class Post(models.Model):
 
     class Meta:
         index_together = ['feed', 'md5sum']
+
+    def __str__(self):
+        """Return a representation including feed and checksum."""
+        feed_str = getattr(self.feed, 'uri', str(self.feed))
+        return f"{feed_str} - {self.md5sum}"
 
 
 class Subscription(models.Model):

--- a/tests/test_model_str.py
+++ b/tests/test_model_str.py
@@ -1,0 +1,42 @@
+import pytest
+
+django = pytest.importorskip('django')
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        INSTALLED_APPS=[
+            'django.contrib.auth',
+            'django.contrib.contenttypes',
+            'frontend.apps.FrontendConfig',
+        ],
+        DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}},
+        SECRET_KEY='test',
+        DEFAULT_AUTO_FIELD='django.db.models.AutoField',
+    )
+    django.setup()
+
+from frontend.models import Feed, Field, FeedField, Post
+
+
+def test_feed_str():
+    feed = Feed(uri='http://example.com', xpath='//item')
+    assert str(feed) == 'http://example.com'
+
+
+def test_field_str():
+    field = Field(name='title', required=True)
+    assert str(field) == 'title'
+
+
+def test_feedfield_str():
+    feed = Feed(uri='http://example.com', xpath='//item')
+    field = Field(name='title', required=True)
+    ff = FeedField(feed=feed, field=field, xpath='.')
+    assert str(ff) == 'http://example.com - title'
+
+
+def test_post_str():
+    feed = Feed(uri='http://example.com', xpath='//item')
+    post = Post(feed=feed, md5sum='abc123')
+    assert str(post) == 'http://example.com - abc123'


### PR DESCRIPTION
## Summary
- implement `__str__` for `Feed`, `Field`, `FeedField` and `Post`
- add tests for these string representations (skipped if Django isn't installed)

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f4fc47ae0832682b797e13c60ac5f