### PR TITLE
Add subscription management page

### DIFF
--- a/frontend/frontend/templates/frontend/dashboard.html
+++ b/frontend/frontend/templates/frontend/dashboard.html
@@ -5,6 +5,9 @@
 <div class="page-header">
   <h1>{% trans 'Dashboard' %}</h1>
 </div>
+<p>
+  <a href="{% url 'manage_subscription' %}" class="btn btn-secondary">{% trans 'Subscription' %}</a>
+</p>
 <table class="table">
   <thead>
     <tr>

--- a/frontend/frontend/templates/frontend/subscription.html
+++ b/frontend/frontend/templates/frontend/subscription.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+<div class="page-header">
+  <h1>{% trans "Subscription" %}</h1>
+</div>
+<table class="table">
+  <tr>
+    <th>{% trans "Plan" %}</th>
+    <td>{{ subscription.plan }}</td>
+  </tr>
+  <tr>
+    <th>{% trans "Status" %}</th>
+    <td>{{ subscription.status }}</td>
+  </tr>
+  <tr>
+    <th>{% trans "Start date" %}</th>
+    <td>{{ subscription.start_date }}</td>
+  </tr>
+  <tr>
+    <th>{% trans "End date" %}</th>
+    <td>{{ subscription.end_date|default:'-' }}</td>
+  </tr>
+</table>
+{% endblock %}

--- a/frontend/frontend/urls.py
+++ b/frontend/frontend/urls.py
@@ -26,6 +26,7 @@ urlpatterns = i18n_patterns(
     url(r'^preview/([0-9]+)$', views.preview, name='preview'),
     url(r'^contact$', views.contact, name='contact'),
     url(r'^dashboard$', views.dashboard, name='dashboard'),
+    url(r'^subscription$', views.manage_subscription, name='manage_subscription'),
     url(r'^admin/', include(admin.site.urls)),
 )
 

--- a/frontend/frontend/views.py
+++ b/frontend/frontend/views.py
@@ -16,7 +16,7 @@ from django.contrib.auth.forms import UserCreationForm
 
 from .setup_tool import get_selection_tag_ids, build_xpathes_for_items
 from .setup_tool_ext import build_xpath_results
-from .models import Feed, Field, FeedField
+from .models import Feed, Field, FeedField, Subscription
 
 def index(request):
     if request.method == 'GET' and 'url' in request.GET:
@@ -252,3 +252,11 @@ def delete_feed(request, feed_id):
         feed = get_object_or_404(Feed, id=feed_id, user=request.user)
         feed.delete()
     return HttpResponseRedirect(reverse('dashboard'))
+
+
+@login_required
+def manage_subscription(request):
+    subscription = get_object_or_404(Subscription, user=request.user)
+    return render(request, 'frontend/subscription.html', {
+        'subscription': subscription,
+    })


### PR DESCRIPTION
## Summary
- show subscription information
- link to subscription page from dashboard
- route `/subscription` to the new view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f4fecbfec8326b1e402fd74cfb7e7