### PR TITLE
Add edit feed view

### DIFF
--- a/frontend/frontend/assets/frontend/js/setup-tool-ext.js
+++ b/frontend/frontend/assets/frontend/js/setup-tool-ext.js
@@ -1,7 +1,8 @@
 (function(){
 
-// skip non setup page
-if (!document.location.href.match('https?://[^/]+/[^/]+/setup\?.+'))
+// skip non setup/edit page
+if (!document.location.href.match('https?://[^/]+/[^/]+/setup\?.+') &&
+    !document.location.href.match('https?://[^/]+/[^/]+/dashboard/edit/\\d+/'))
     return;
 
 function save(key, obj) {

--- a/frontend/frontend/assets/frontend/js/setup-tool.js
+++ b/frontend/frontend/assets/frontend/js/setup-tool.js
@@ -475,8 +475,9 @@ function loader(show) {
 window.loader = loader;
 
 $(document).ready(function(){
-    // skip non setup page
-    if (!document.location.href.match('https?://[^/]+/[^/]+/setup\?.+'))
+    // skip non setup/edit page
+    if (!document.location.href.match('https?://[^/]+/[^/]+/setup\?.+') &&
+        !document.location.href.match('https?://[^/]+/[^/]+/dashboard/edit/\\d+/'))
         return;
 
     loader(true);

--- a/frontend/frontend/templates/frontend/dashboard.html
+++ b/frontend/frontend/templates/frontend/dashboard.html
@@ -23,7 +23,7 @@
       <td>{{ feed.created|date:"Y-m-d H:i" }}</td>
       <td>
         <a class="btn btn-sm btn-primary" href="{% url 'preview' feed.id %}">{% trans 'View' %}</a>
-        <a class="btn btn-sm btn-secondary" href="{% url 'setup' %}?url={{ feed.uri|urlencode }}">{% trans 'Edit' %}</a>
+        <a class="btn btn-sm btn-secondary" href="{% url 'edit_feed' feed.id %}">{% trans 'Edit' %}</a>
         <form method="post" action="{% url 'delete_feed' feed.id %}" style="display:inline;">
           {% csrf_token %}
           <button type="submit" class="btn btn-sm btn-danger">{% trans 'Delete' %}</button>

--- a/frontend/frontend/templates/frontend/setup.html
+++ b/frontend/frontend/templates/frontend/setup.html
@@ -257,5 +257,13 @@ li.ext-result dl {
             iframe_element = this;
             update_iframe_heignt();
         });
+
+        {% if feed_config_json %}
+        $(function(){
+            if (window.ET && typeof ET.updateUI === 'function') {
+                ET.updateUI({{ feed_config_json|safe }});
+            }
+        });
+        {% endif %}
     </script>
 {% endblock %}

--- a/frontend/frontend/urls.py
+++ b/frontend/frontend/urls.py
@@ -34,6 +34,7 @@ urlpatterns += [
     path('accounts/', include('django.contrib.auth.urls')),
     path('register/', views.register, name='register'),
     path('dashboard/delete/<int:feed_id>/', views.delete_feed, name='delete_feed'),
+    path('dashboard/edit/<int:feed_id>/', views.edit_feed, name='edit_feed'),
 ]
 
 urlpatterns.append(url(r'^setup_get_selected_ids$', views.setup_get_selected_ids, name='setup_get_selected_ids'))

--- a/frontend/frontend/views.py
+++ b/frontend/frontend/views.py
@@ -255,6 +255,24 @@ def delete_feed(request, feed_id):
 
 
 @login_required
+def edit_feed(request, feed_id):
+    feed = get_object_or_404(Feed, id=feed_id, user=request.user)
+    feed_fields = FeedField.objects.filter(feed=feed).select_related('field')
+
+    config = [feed.xpath, {}]
+    for ff in feed_fields:
+        config[1][ff.field.name] = ff.xpath
+
+    external_page_url = DOWNLOADER_PAGE_URL + urllib.parse.quote(feed.uri, safe='')
+
+    return render(request, 'frontend/setup.html', {
+        'external_page_url': external_page_url,
+        'page_url': feed.uri,
+        'feed_config_json': json.dumps(config),
+    })
+
+
+@login_required
 def manage_subscription(request):
     subscription = get_object_or_404(Subscription, user=request.user)
     return render(request, 'frontend/subscription.html', {

--- a/tests/test_edit_feed_view.py
+++ b/tests/test_edit_feed_view.py
@@ -1,0 +1,55 @@
+import os
+import pytest
+
+django = pytest.importorskip('django')
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        SECRET_KEY='test',
+        ROOT_URLCONF='frontend.urls',
+        INSTALLED_APPS=[
+            'django.contrib.auth',
+            'django.contrib.contenttypes',
+            'django.contrib.sessions',
+            'frontend.apps.FrontendConfig',
+        ],
+        DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}},
+        MIDDLEWARE=[
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.middleware.common.CommonMiddleware',
+            'django.middleware.csrf.CsrfViewMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+        ],
+        TEMPLATES=[{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}],
+        STATIC_URL='/static/',
+        DEFAULT_AUTO_FIELD='django.db.models.AutoField',
+    )
+    django.setup()
+
+from django.urls import reverse
+from django.test import Client
+from django.contrib.auth.models import User
+from frontend.models import Feed, Field, FeedField
+
+
+def test_edit_feed_prefills_selectors():
+    user = User.objects.create_user('u', password='p')
+
+    title = Field.objects.create(id=1, name='title', required=True)
+    description = Field.objects.create(id=2, name='description', required=False)
+    link = Field.objects.create(id=3, name='link', required=True)
+
+    feed = Feed.objects.create(uri='http://example.com', xpath='//div', user=user)
+    FeedField.objects.create(feed=feed, field=title, xpath='./a/text()')
+    FeedField.objects.create(feed=feed, field=link, xpath='./a/@href')
+    FeedField.objects.create(feed=feed, field=description, xpath='./p/text()')
+
+    client = Client()
+    client.force_login(user)
+    url = reverse('edit_feed', args=[feed.id])
+    resp = client.get(url)
+    assert resp.status_code == 200
+    content = resp.content.decode('utf-8')
+    assert './a/text()' in content
+    assert './p/text()' in content


### PR DESCRIPTION
## Summary
- implement edit_feed to load saved selectors
- register edit_feed URL and update dashboard link
- preload selectors when rendering setup page
- enable JS on edit URLs
- test edit_feed view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5570f3848326bb5a9df17a7b7807