### PR TITLE
Add dark theme toggle

### DIFF
--- a/frontend/frontend/assets/frontend/stylesheets/dark-theme.scss
+++ b/frontend/frontend/assets/frontend/stylesheets/dark-theme.scss
@@ -1,0 +1,27 @@
+// Dark theme variables
+$dark-bg: #121212;
+$dark-text: #f8f9fa;
+$dark-navbar-bg: #343a40;
+$dark-link: #0d6efd;
+
+body.dark-mode {
+  background-color: $dark-bg;
+  color: $dark-text;
+}
+
+body.dark-mode a {
+  color: $dark-link;
+}
+
+body.dark-mode .navbar {
+  background-color: $dark-navbar-bg !important;
+}
+
+body.dark-mode .navbar .nav-link {
+  color: $dark-text !important;
+}
+
+body.dark-mode #footer {
+  background-color: $dark-navbar-bg;
+  color: $dark-text;
+}

--- a/frontend/frontend/settings.py
+++ b/frontend/frontend/settings.py
@@ -140,6 +140,7 @@ PIPELINE_CSS = {
           'frontend/stylesheets/application.css',
           'frontend/stylesheets/bootstrap5_and_overrides.scss',
           'frontend/stylesheets/wizard.css.scss',
+          'frontend/stylesheets/dark-theme.scss',
           'frontend/stylesheets/google-code-prettify/prettify.css',
         ),
         'output_filename': 'frontend/stylesheets/app.css',

--- a/frontend/frontend/templates/base.html
+++ b/frontend/frontend/templates/base.html
@@ -59,6 +59,7 @@
 
             <li>{% if LANGUAGE_CODE == 'en' %} <a href="/ru/" class="lang"><span class="lang">Русский</span></a> {% else %} <span class="lang">Русский</span> {% endif %}
             <li><div class="vr mx-2"></div></li>
+            <li><button id="theme-toggle" class="btn btn-link nav-link p-0">Dark Mode</button></li>
             <li><a href="{% url 'contact' %}">{% trans "contact" %}</a></li>
             {% if user.is_authenticated %}
             <li><a href="{% url 'dashboard' %}">Dashboard</a></li>
@@ -88,10 +89,27 @@
   <div class="push"></div>
 </div>
 </div>
-<div id="footer">
-  <div class="container">
-    <p class="credit">{% trans 'made_by' %} <a href="https://github.com/taroved" target="_blank">{% trans 'made_name' %}</a></p>
+  <div id="footer">
+    <div class="container">
+      <p class="credit">{% trans 'made_by' %} <a href="https://github.com/taroved" target="_blank">{% trans 'made_name' %}</a></p>
+    </div>
   </div>
-</div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var btn = document.getElementById('theme-toggle');
+      function applyTheme(isDark) {
+        document.body.classList.toggle('dark-mode', isDark);
+      }
+      var isDark = localStorage.getItem('theme') === 'dark';
+      applyTheme(isDark);
+      if (btn) {
+        btn.addEventListener('click', function() {
+          isDark = !document.body.classList.contains('dark-mode');
+          applyTheme(isDark);
+          localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        });
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement a dark theme stylesheet
- include the dark theme in Pipeline CSS sources
- add a toggle button to switch themes and store preference in localStorage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f572c15b8832699a63917cf828084