### PR TITLE
Add dashboard search filter

### DIFF
--- a/frontend/frontend/templates/frontend/dashboard.html
+++ b/frontend/frontend/templates/frontend/dashboard.html
@@ -8,6 +8,12 @@
 <p>
   <a href="{% url 'manage_subscription' %}" class="btn btn-secondary">{% trans 'Subscription' %}</a>
 </p>
+<form method="get" class="mb-3">
+  <div class="input-group">
+    <input type="text" name="q" class="form-control" placeholder="{% trans 'Search' %}" value="{{ request.GET.q }}">
+    <button type="submit" class="btn btn-primary">{% trans 'Search' %}</button>
+  </div>
+</form>
 <table class="table">
   <thead>
     <tr>

--- a/frontend/frontend/views.py
+++ b/frontend/frontend/views.py
@@ -242,7 +242,11 @@ def register(request):
 
 @login_required
 def dashboard(request):
-    feeds = Feed.objects.filter(user=request.user).order_by('-created')
+    feeds = Feed.objects.filter(user=request.user)
+    query = request.GET.get('q')
+    if query:
+        feeds = feeds.filter(uri__icontains=query)
+    feeds = feeds.order_by('-created')
     return render(request, 'frontend/dashboard.html', {'feeds': feeds})
 
 

--- a/tests/test_dashboard_view.py
+++ b/tests/test_dashboard_view.py
@@ -1,0 +1,51 @@
+import pytest
+
+django = pytest.importorskip('django')
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        SECRET_KEY='test',
+        ROOT_URLCONF='frontend.urls',
+        INSTALLED_APPS=[
+            'django.contrib.auth',
+            'django.contrib.contenttypes',
+            'django.contrib.sessions',
+            'frontend.apps.FrontendConfig',
+        ],
+        DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}},
+        MIDDLEWARE=[
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.middleware.common.CommonMiddleware',
+            'django.middleware.csrf.CsrfViewMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+        ],
+        TEMPLATES=[{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}],
+        STATIC_URL='/static/',
+        DEFAULT_AUTO_FIELD='django.db.models.AutoField',
+    )
+    django.setup()
+
+from django.urls import reverse
+from django.test import Client
+from django.contrib.auth.models import User
+from frontend.models import Feed
+
+
+def test_dashboard_filters_by_query():
+    user = User.objects.create_user('u', password='p')
+    other_user = User.objects.create_user('o', password='p')
+
+    Feed.objects.create(uri='http://example.com/match', xpath='//div', user=user)
+    Feed.objects.create(uri='http://nomatch.com/feed', xpath='//div', user=user)
+    Feed.objects.create(uri='http://example.com/other', xpath='//div', user=other_user)
+
+    client = Client()
+    client.force_login(user)
+    url = reverse('dashboard')
+    resp = client.get(url, {'q': 'example'})
+    assert resp.status_code == 200
+    content = resp.content.decode('utf-8')
+    assert 'http://example.com/match' in content
+    assert 'http://nomatch.com/feed' not in content
+    assert 'http://example.com/other' not in content


### PR DESCRIPTION
## Summary
- add search form to dashboard template
- filter feeds by search query in dashboard view
- test dashboard filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5996993c8326b56e53f863f08be5