### PR TITLE
Add subscription management

### DIFF
--- a/frontend/frontend/templates/frontend/subscription.html
+++ b/frontend/frontend/templates/frontend/subscription.html
@@ -23,4 +23,22 @@
     <td>{{ subscription.end_date|default:'-' }}</td>
   </tr>
 </table>
+
+<form method="post" action="{% url 'update_subscription' %}" class="mb-3">
+  {% csrf_token %}
+  <div class="mb-3">
+    <label for="plan" class="form-label">{% trans "Plan" %}</label>
+    <select name="plan" id="plan" class="form-select">
+      <option value="basic" {% if subscription.plan == 'basic' %}selected{% endif %}>Basic</option>
+      <option value="premium" {% if subscription.plan == 'premium' %}selected{% endif %}>Premium</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">{% trans "Update" %}</button>
+</form>
+
+<form method="post" action="{% url 'update_subscription' %}">
+  {% csrf_token %}
+  <input type="hidden" name="cancel" value="1">
+  <button type="submit" class="btn btn-danger">{% trans "Cancel subscription" %}</button>
+</form>
 {% endblock %}

--- a/frontend/frontend/urls.py
+++ b/frontend/frontend/urls.py
@@ -27,6 +27,7 @@ urlpatterns = i18n_patterns(
     url(r'^contact$', views.contact, name='contact'),
     url(r'^dashboard$', views.dashboard, name='dashboard'),
     url(r'^subscription$', views.manage_subscription, name='manage_subscription'),
+    path('subscription/update/', views.update_subscription, name='update_subscription'),
     url(r'^admin/', include(admin.site.urls)),
 )
 

--- a/frontend/frontend/views.py
+++ b/frontend/frontend/views.py
@@ -5,6 +5,7 @@ import re
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.http import HttpResponseRedirect, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render, get_object_or_404
+from django.utils import timezone
 from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
 from django.urls import reverse
@@ -282,3 +283,23 @@ def manage_subscription(request):
     return render(request, 'frontend/subscription.html', {
         'subscription': subscription,
     })
+
+
+@login_required
+def update_subscription(request):
+    if request.method != 'POST':
+        return HttpResponseBadRequest('Only POST method supported')
+
+    subscription = get_object_or_404(Subscription, user=request.user)
+
+    if 'cancel' in request.POST:
+        subscription.status = 'canceled'
+        subscription.end_date = timezone.now().date()
+        subscription.save()
+    elif 'plan' in request.POST:
+        subscription.plan = request.POST['plan']
+        subscription.status = 'active'
+        subscription.end_date = None
+        subscription.save()
+
+    return HttpResponseRedirect(reverse('manage_subscription'))

--- a/tests/test_update_subscription_view.py
+++ b/tests/test_update_subscription_view.py
@@ -1,0 +1,60 @@
+import pytest
+
+django = pytest.importorskip('django')
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        SECRET_KEY='test',
+        ROOT_URLCONF='frontend.urls',
+        INSTALLED_APPS=[
+            'django.contrib.auth',
+            'django.contrib.contenttypes',
+            'django.contrib.sessions',
+            'frontend.apps.FrontendConfig',
+        ],
+        DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}},
+        MIDDLEWARE=[
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.middleware.common.CommonMiddleware',
+            'django.middleware.csrf.CsrfViewMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+        ],
+        TEMPLATES=[{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}],
+        STATIC_URL='/static/',
+        DEFAULT_AUTO_FIELD='django.db.models.AutoField',
+        DEFAULT_PLAN='basic',
+    )
+    django.setup()
+
+from django.urls import reverse
+from django.test import Client
+from django.contrib.auth.models import User
+from django.utils import timezone
+from frontend.models import Subscription
+
+
+def test_update_subscription_plan():
+    user = User.objects.create_user('u', password='p')
+    client = Client()
+    client.force_login(user)
+    url = reverse('update_subscription')
+    resp = client.post(url, {'plan': 'premium'})
+    assert resp.status_code == 302
+    sub = Subscription.objects.get(user=user)
+    assert sub.plan == 'premium'
+    assert sub.status == 'active'
+    assert sub.end_date is None
+
+
+def test_cancel_subscription():
+    user = User.objects.create_user('u2', password='p')
+    client = Client()
+    client.force_login(user)
+    url = reverse('update_subscription')
+    today = timezone.now().date()
+    resp = client.post(url, {'cancel': '1'})
+    assert resp.status_code == 302
+    sub = Subscription.objects.get(user=user)
+    assert sub.status == 'canceled'
+    assert sub.end_date == today


### PR DESCRIPTION
## Summary
- allow users to change or cancel subscription via new view
- add forms on subscription page for plan updates/canceling
- route update view in URLs
- test subscription update logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff425f1b88326a7211bf1d50bae4c