### PR TITLE
Convert feed_id to integer

### DIFF
--- a/pol/server.py
+++ b/pol/server.py
@@ -353,7 +353,7 @@ class Site(resource.Resource):
             return NOT_DONE_YET
         elif self.feed_regexp.match(request.uri) is not None: # feed
 
-            feed_id = self.feed_regexp.match(request.uri).groups()[0]
+            feed_id = int(self.feed_regexp.match(request.uri).group(1))
             sanitize = request.uri.endswith(b'?sanitize=Y')
             if b'sanitize' in request.args:
                 sanitize = request.args[b'sanitize'][0] == b'Y'


### PR DESCRIPTION
## Summary
- parse feed ID as integer in `Site.render_GET`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684044c1356c8326b75df56be4d29968